### PR TITLE
fix live msgs written to index

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "nano-equal": "^2.0.2",
+    "pull-cat": "^1.1.11",
     "pull-stream": "^3.6.14",
     "ssb-db2": "github:ssb-ngi-pointer/ssb-db2#publishAs-simple",
     "ssb-ref": "^2.13.0"

--- a/test/index.js
+++ b/test/index.js
@@ -121,7 +121,7 @@ test('update index feed for votes a bit', (t) => {
   )
 })
 
-test('update index feed for votes entirely', async (t) => {
+test('restarting sbot continues writing index where left off', async (t) => {
   sbot = SecretStack({ appKey: caps.shs })
     .use(require('ssb-db2'))
     .use(require('ssb-meta-feeds'))
@@ -149,6 +149,22 @@ test('update index feed for votes entirely', async (t) => {
   t.equals(allVotes.length, VOTES_COUNT, 'all votes were indexed')
 
   t.end()
+})
+
+test('live updates get written to the index', (t) => {
+  sbot.db.publish({ type: 'vote', vote: { value: 1 } }, async (err) => {
+    t.error(err, 'no err')
+
+    await sleep(300)
+
+    const allVotes = await sbot.db.query(
+      where(author(indexFeedID)),
+      toPromise()
+    )
+    t.equals(allVotes.length, VOTES_COUNT + 1, 'one more vote was indexed')
+
+    t.end()
+  })
 })
 
 test('teardown', (t) => {


### PR DESCRIPTION
1st :x: 2nd :heavy_check_mark: 

-----

There were basically three possible solutions:

**A** (what's currently in master branch)

```js
pull(
  sbot.db.query(
    where(and(matchesQuery, gt(latestSequence, 'sequence'))),
    live({ old: true }),
    paginate(50),
    toPullStream()
  ),
  pull.map(pull.values),
  pull.flatten()  
)
```

**B**

```js
sbot.db.query(
  where(and(matchesQuery, gt(latestSequence, 'sequence'))),
  live({ old: true }),
  toPullStream()
)
```

**C**

```js
cat([
  pull(
    sbot.db.query(
      where(and(matchesQuery, gt(latestSequence, 'sequence'))),
      paginate(50),
      toPullStream()
    ),
    pull.map(pull.values),
    pull.flatten()
  ),
  sbot.db.query(
    where(matchesQuery), 
    live(), 
    toPullStream()
  ),
])
```

----

Solutions **A** and **B** require the fix in JITDB. But actually, solution **A** doesn't work because the `pull.map(pull.values)` at the end is intended for the paginated (old) stuff, and breaks with live values. Solution **B** works (if JITDB is patched) but it has the downside of being less performant in the case of old values, because the pagination=50 is useful.

So that leaves us with solution **C** which does **not** need JITDB to be patched. It's still useful to fix JITDB, I guess.
