### PR TITLE
fix tests by avoiding setTimeout hacks

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "ssb-caps": "^1.1.0",
     "ssb-fixtures": "^2.4.1",
     "ssb-keys": "^8.2.0",
-    "ssb-meta-feeds": "~0.18.0",
+    "ssb-meta-feeds": "~0.18.1",
     "tap-bail": "^1.0.0",
     "tap-spec": "^5.0.0",
     "tape": "^5.2.2"


### PR DESCRIPTION
## Context

CI was failing: https://github.com/ssb-ngi-pointer/ssb-index-feed-writer/runs/3522709764

I tried to get to the bottom of *why* they weren't failing, but I didn't quite figure it out yet. But it didn't matter because I rewrote the test in a better way

## Problem

Something related to setTimeouts and waiting periods that wasn't quite right. The setTimeout solution was anyway hacky and provisional, because all that we wanted was just a way of abruptly (but deterministically) aborting the *index feed writing* so that we could subsequently test that sbot continues where it stopped from.

## Solution

Removed the setTimeout hacks and used a counter (`published`) to track how many messages have been published so far, and then aborting the operation once that number reaches 3. Note, there is still one `setTimeout` there (with no `period` argument, which means it just schedules it to run asynchronously later, but as soon as possible), this was necessary to break some underlying chain of synchronous executions in ssb-db2.