### PR TITLE
test that start() arg can be a string

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "pull-cat": "^1.1.11",
     "pull-stream": "^3.6.14",
     "ssb-db2": "^2.4.0",
-    "ssb-subset-ql": "~0.3.0"
+    "ssb-subset-ql": "0.3.0"
   },
   "peerDependencies": {
     "ssb-meta-feeds": ">=0.18.0"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "pull-cat": "^1.1.11",
     "pull-stream": "^3.6.14",
     "ssb-db2": "^2.4.0",
-    "ssb-subset-ql": "0.3.0"
+    "ssb-subset-ql": "~0.4.0"
   },
   "peerDependencies": {
     "ssb-meta-feeds": ">=0.18.0"

--- a/test/index.js
+++ b/test/index.js
@@ -138,10 +138,12 @@ test('restarting sbot continues writing index where left off', async (t) => {
   t.equals(votes.length, 3, '3 votes previously indexed')
 
   t.pass('started task')
-  const [err, indexFeed] = await run(sbot.indexFeedWriter.start)({
-    author: sbot.id,
-    type: 'vote',
-  })
+  const [err, indexFeed] = await run(sbot.indexFeedWriter.start)(
+    JSON.stringify({
+      author: sbot.id,
+      type: 'vote',
+    })
+  )
   t.error(err, 'no err')
   t.ok(indexFeed, 'index feed returned')
   t.equals(indexFeed.subfeed, indexFeedID, 'it is the same as before')


### PR DESCRIPTION
First commit tests that the input argument to `start()` can be a string, and shows that the current implementation would fail (:x: in CI).

Second commit updates ssb-subset-ql to fix the tests. :heavy_check_mark: 