### PR TITLE
add config autostart

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,8 @@ There is one primary API this plugin provides: `start()`. You pass it a
 `ssb-ql-0` query and it will detect whether it needs to create an index feed for
 that query, or update an existing index feed.
 
-
 ```js
-sbot.indexFeedWriter.start({author: sbot.id, type: 'vote'}, (err, index) => {
+sbot.indexFeedWriter.start({ author: sbot.id, type: 'vote' }, (err, index) => {
   console.log('The index feed is ' + index.subfeed)
 })
 ```
@@ -66,6 +65,32 @@ _Cancels the updating of the index feed for the given query, if it had started_
 `query` must be an `ssb-ql-0` query, either as stringified JSON or as an object.
 
 Does not return anything as a response.
+
+## Configuration
+
+Some behaviors of this module can be configured by the user or by application
+code through the conventional [ssb-config](https://github.com/ssbc/ssb-config)
+object. The possible options are listed below:
+
+```js
+{
+  indexFeedWriter: {
+    /**
+     * If `autostart` is defined as an array, it informs ssb-index-feed-writer
+     * to automatically call `start()` with each of the array items, as soon as
+     * this plugin is initialized.
+     *
+     * The array items are just ssb-ql-0 objects, except without the `author`
+     * property, because that one will always be implicitly equal to `sbot.id`.
+     */
+    autostart: [
+      { type: 'vote', private: false },
+      { type: 'post', private: false },
+      { type: null, private: true },
+    ]
+  }
+}
+```
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ exports.manifest = {
   stop: 'sync',
 }
 
-exports.init = function init(sbot) {
+exports.init = function init(sbot, config) {
   if (!sbot.db || !sbot.db.query) {
     throw new Error('ssb-index-feed-writer requires ssb-db2')
   }
@@ -39,6 +39,21 @@ exports.init = function init(sbot) {
       { feedpurpose: 'indexes', feedformat: 'bendybutt-v1' }
     )
   )
+
+  if (
+    config &&
+    config.indexFeedWriter &&
+    Array.isArray(config.indexFeedWriter.autostart)
+  ) {
+    setTimeout(() => {
+      for (const incompleteQuery of config.indexFeedWriter.autostart) {
+        const query = { ...incompleteQuery, author: sbot.id }
+        sbot.indexFeedWriter.start(query, (err) => {
+          if (err) console.error(err)
+        })
+      }
+    })
+  }
 
   /**
    * Data structure that tracks all indexes being synchronized.


### PR DESCRIPTION
This is not an absolute necessity but it will make it easier to write end-to-end tests and maybe also integration in end-user applications will be easier.

Previously, we had to explicitly call `start(query, cb)` on each index feed, upon starting the sbot.

Now, we have an alternative way: `config.indexFeedWriter.autostart`, see the README for more instructions.

Other examples of `autostart` can be found e.g. in [ssb-conn](https://github.com/staltz/ssb-conn/#config)