### PR TITLE
root MF is created lazily, on 1st start()

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,15 +30,7 @@ exports.init = function init(sbot, config) {
     throw new Error('ssb-index-feed-writer requires ssb-meta-feeds')
   }
 
-  const rootMetafeedP = pify(sbot.metafeeds.findOrCreate)()
-
-  const indexesMetafeedP = rootMetafeedP.then((metafeed) =>
-    pify(sbot.metafeeds.findOrCreate)(
-      metafeed,
-      (f) => f.feedpurpose === 'indexes',
-      { feedpurpose: 'indexes', feedformat: 'bendybutt-v1' }
-    )
-  )
+  let indexesMetafeedP
 
   if (
     config &&
@@ -161,6 +153,16 @@ exports.init = function init(sbot, config) {
       cb(new Error('Can only index our own messages, but got author ' + author))
     }
 
+    if (!indexesMetafeedP) {
+      const rootMetafeedP = pify(sbot.metafeeds.findOrCreate)()
+      indexesMetafeedP = rootMetafeedP.then((metafeed) =>
+        pify(sbot.metafeeds.findOrCreate)(
+          metafeed,
+          (f) => f.feedpurpose === 'indexes',
+          { feedpurpose: 'indexes', feedformat: 'bendybutt-v1' }
+        )
+      )
+    }
     const indexesMF = await indexesMetafeedP
 
     sbot.metafeeds.findOrCreate(

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "promisify-4loc": "^1.0.0",
     "pull-cat": "^1.1.11",
     "pull-stream": "^3.6.14",
-    "ssb-db2": "^2.4.0",
+    "ssb-db2": "^2.5.1",
     "ssb-subset-ql": "~0.6.1"
   },
   "peerDependencies": {
@@ -32,7 +32,7 @@
     "ssb-caps": "^1.1.0",
     "ssb-fixtures": "^2.4.1",
     "ssb-keys": "^8.2.0",
-    "ssb-meta-feeds": "~0.18.2",
+    "ssb-meta-feeds": "~0.19.0",
     "tap-bail": "^1.0.0",
     "tap-spec": "^5.0.0",
     "tape": "^5.2.2"

--- a/test/index.js
+++ b/test/index.js
@@ -15,6 +15,7 @@ const generateFixture = require('ssb-fixtures')
 const {
   where,
   and,
+  authorIsBendyButtV1,
   author,
   type,
   count,
@@ -117,15 +118,21 @@ test('update index feed for votes a bit', (t) => {
     })
   }
 
-  sbot.indexFeedWriter.start(
-    { author: sbot.id, type: 'vote', private: false },
-    (err, indexFeed) => {
-      t.pass('started task')
-      t.error(err, 'no err')
-      t.ok(indexFeed, 'index feed returned')
-      indexFeedID = indexFeed.subfeed
-    }
-  )
+  // Lets check that creation of the root meta feed is lazy
+  setTimeout(async () => {
+    const msgs = await sbot.db.query(where(authorIsBendyButtV1()), toPromise())
+    t.equals(msgs.length, 0, 'zero bendy butt messages')
+
+    sbot.indexFeedWriter.start(
+      { author: sbot.id, type: 'vote', private: false },
+      (err, indexFeed) => {
+        t.pass('started task')
+        t.error(err, 'no err')
+        t.ok(indexFeed, 'index feed returned')
+        indexFeedID = indexFeed.subfeed
+      }
+    )
+  }, 3000)
 })
 
 test('restarting sbot continues writing index where left off', async (t) => {


### PR DESCRIPTION
Previously, this module was creating (via `findOrCreate`) the root meta feed as soon as this module was installed. But this makes writing tests (in other libraries) harder because we want to have some control over the existence/absence of the root meta feed (and the indexes meta feed too).

So this PR just creates the root meta feed and indexes meta feed whenever it's obvious that we'll need them, i.e. on the first call to `start()`.