### PR TITLE
use ssb-meta-feeds 0.33 with shards

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,36 +14,38 @@
   ],
   "dependencies": {
     "debug": "^4.3.2",
+    "is-canonical-base64": "^1.1.1",
     "promisify-4loc": "^1.0.0",
     "pull-cat": "^1.1.11",
     "pull-stream": "^3.6.14",
     "ssb-classic": "^1.0.3",
-    "ssb-db2": ">=5.0.0",
+    "ssb-db2": ">=5",
+    "ssb-keys": ">=8",
     "ssb-ref": "^2.16.0",
     "ssb-subset-ql": "^1.0.0",
     "ssb-uri2": "^2.1.0"
   },
   "peerDependencies": {
-    "ssb-meta-feeds": ">=0.30.0"
+    "ssb-meta-feeds": ">=0.33.0"
   },
   "devDependencies": {
     "husky": "^4.3.0",
+    "mkdirp": "^1.0.4",
     "nyc": "^15.1.0",
     "prettier": "^2.1.2",
     "pretty-quick": "^3.1.0",
     "promisify-tuple": "^1.2.0",
-    "mkdirp": "^1.0.4",
     "rimraf": "^3.0.2",
     "secret-stack": "^6.4.0",
     "ssb-bendy-butt": "^1.0.1",
-    "ssb-db2": "^6.1.1",
     "ssb-caps": "^1.1.0",
+    "ssb-db2": "^6.2.2",
     "ssb-feed-format": "2.2.3",
     "ssb-fixtures": "^2.4.1",
     "ssb-keys": "^8.5.0",
-    "ssb-meta-feeds": "~0.30.0",
+    "ssb-meta-feeds": "~0.33.0",
     "tap-arc": "^0.3.5",
-    "tape": "^5.5.3"
+    "tape": "^5.6.1"
   },
   "scripts": {
     "test": "tape test/*.js | tap-arc --bail",


### PR DESCRIPTION
**Context:** I'm working on ssb-replication-scheduler, and it uses a lot of index feeds to test partial replication scenarios.

**Problem:** ssb-index-feeds was still using the old ssb-meta-feeds API where you have to findOrCreate each step.

**Solution:** update ssb-meta-feeds to 0.33.0 and use the new findOrCreate which is internally aware of shards.